### PR TITLE
SUNM-36464 Fix tracer uninitialized constant

### DIFF
--- a/lib/ruby_apm/agent/newrelic.rb
+++ b/lib/ruby_apm/agent/newrelic.rb
@@ -7,6 +7,7 @@ module RubyApm
       DEPENDENCIES = ['newrelic_rpm'].freeze
 
       if defined?(Rails)
+        require 'new_relic/agent'
         # tracers for Rails apps
         class Railtie < Rails::Railtie
           initializer 'newrelic_rpm.include_method_tracers', before: :load_config_initializers do


### PR DESCRIPTION
Require newrelic agent to avoid uninitialized constant on pre config load hook